### PR TITLE
feat: Implement custom/existing NPC appearance system

### DIFF
--- a/S1API/Entities/Appearances/AccessoryFields/Bottom.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Bottom.cs
@@ -1,0 +1,14 @@
+﻿using S1API.Entities.Appearances.Base;
+using System.Reflection;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Bottom index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Bottom : BaseAccessoryAppearance
+    {
+        public const string LongSkirt = "Avatar/Accessories/Bottom/LongSkirt/LongSkirt";
+        public const string MediumSkirt = "Avatar/Accessories/Bottom/MediumSkirt/MediumSkirt";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Chest.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Chest.cs
@@ -1,0 +1,16 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Chest index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Chest : BaseAccessoryAppearance
+    {
+        public const string Blazer = "Avatar/Accessories/Chest/Blazer/Blazer";
+        public const string BulletProofVest = "Avatar/Accessories/Chest/BulletProofVest/BulletProofVest";
+        public const string BulletProofVestPolice = "Avatar/Accessories/Chest/BulletProofVest/BulletProofVest_Police";
+        public const string CollarJacket = "Avatar/Accessories/Chest/CollarJacket/CollarJacket";
+        public const string OpenVest = "Avatar/Accessories/Chest/OpenVest/OpenVest";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Feet.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Feet.cs
@@ -1,0 +1,16 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Feet index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Feet : BaseAccessoryAppearance
+    {
+        public const string CombatShoes = "Avatar/Accessories/Feet/CombatShoes/CombatShoes";
+        public const string DressShoes = "Avatar/Accessories/Feet/DressShoes/DressShoes";
+        public const string Flats = "Avatar/Accessories/Feet/Flats/Flats";
+        public const string Sandals = "Avatar/Accessories/Feet/Sandals/Sandals";
+        public const string Sneakers = "Avatar/Accessories/Feet/Sneakers/Sneakers";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Hands.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Hands.cs
@@ -1,0 +1,12 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Hands index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Hands : BaseAccessoryAppearance
+    {
+        public const string Polex = "Avatar/Accessories/Hands/Polex/Polex";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Head.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Head.cs
@@ -1,0 +1,25 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Head index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Head : BaseAccessoryAppearance
+    {
+        public const string BucketHat = "Avatar/Accessories/Head/BucketHat/BucketHat";
+        public const string Cap = "Avatar/Accessories/Head/Cap/Cap";
+        public const string CapFastFood = "Avatar/Accessories/Head/Cap/Cap_FastFood";
+        public const string ChefHat = "Avatar/Accessories/Head/ChefHat/ChefHat";
+        public const string CowboyHat = "Avatar/Accessories/Head/Cowboy/CowboyHat";
+        public const string FlatCap = "Avatar/Accessories/Head/FlatCap/FlatCap";
+        public const string LegendSunglasses = "Avatar/Accessories/Head/LegendSunglasses/LegendSunglasses";
+        public const string Oakleys = "Avatar/Accessories/Head/Oakleys/Oakleys";
+        public const string PoliceCap = "Avatar/Accessories/Head/PoliceCap/PoliceCap";
+        public const string PorkpieHat = "Avatar/Accessories/Head/PorkpieHat/PorkpieHat";
+        public const string RectangleFrameGlasses = "Avatar/Accessories/Head/RectangleFrameGlasses/RectangleFrameGlasses";
+        public const string Respirator = "Avatar/Accessories/Head/Respirator/Respirator";
+        public const string SaucePan = "Avatar/Accessories/Head/SaucePan/SaucePan";
+        public const string SmallRoundGlasses = "Avatar/Accessories/Head/SmallRoundGlasses/SmallRoundGlasses";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Neck.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Neck.cs
@@ -1,0 +1,12 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Neck index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Neck : BaseAccessoryAppearance
+    {
+        public const string GoldChain = "Avatar/Accessories/Neck/GoldChain/GoldChain";
+    }
+}

--- a/S1API/Entities/Appearances/AccessoryFields/Waist.cs
+++ b/S1API/Entities/Appearances/AccessoryFields/Waist.cs
@@ -1,0 +1,16 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.AccessoryFields
+{
+    /// <summary>
+    /// The Waist index in AvatarSettings::AccessorySettings
+    /// </summary>
+    public class Waist : BaseAccessoryAppearance
+    {
+        public const string Apron = "Avatar/Accessories/Waist/Apron/Apron";
+        public const string Belt = "Avatar/Accessories/Waist/Belt/Belt";
+        public const string HazmatSuit = "Avatar/Accessories/Waist/HazmatSuit/HazmatSuit";
+        public const string PoliceBelt = "Avatar/Accessories/Waist/PoliceBelt/PoliceBelt";
+        public const string PriestGown = "Avatar/Accessories/Neck/PriestGown/PriestGown";
+    }
+}

--- a/S1API/Entities/Appearances/Base/BaseAccessoryAppearance.cs
+++ b/S1API/Entities/Appearances/Base/BaseAccessoryAppearance.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace S1API.Entities.Appearances.Base
+{
+    /// <summary>
+    /// The base accessory appearance class
+    /// </summary>
+    /// <remarks>This is used to track the properties within the AvatarSettings</remarks>
+    public class BaseAccessoryAppearance
+    {
+        private static readonly Dictionary<Type, List<string>> _constCache = new Dictionary<Type, List<string>>();
+
+        /// <summary>
+        /// Retrieves and caches all public <c>const string</c> fields defined in the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type from which to retrieve constant string fields. Must inherit from <see cref="BaseAccessoryAppearance"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A list of constant string values defined in the type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// Uses reflection to gather constants and caches them for future calls to improve performance.
+        /// </remarks>
+        internal static List<string> GetConstPaths<T>() where T : BaseAccessoryAppearance
+        {
+            var type = typeof(T);
+            if (_constCache.TryGetValue(type, out var cached))
+                return cached;
+
+            var consts = new List<string>();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            foreach (var field in fields)
+            {
+                if (field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(string))
+                    consts.Add((string)field.GetRawConstantValue());
+            }
+
+            _constCache[type] = consts;
+            return consts;
+        }
+    }
+}

--- a/S1API/Entities/Appearances/Base/BaseAppearance.cs
+++ b/S1API/Entities/Appearances/Base/BaseAppearance.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace S1API.Entities.Appearances.Base
+{
+    /// <summary>
+    /// The base appearance class
+    /// </summary>
+    /// <remarks>This is used to track the properties within the AvatarSettings</remarks>
+    public class BaseAppearance
+    {
+        private static readonly Dictionary<Type, List<string>> _constCache = new Dictionary<Type, List<string>>();
+
+        /// <summary>
+        /// Retrieves and caches all public <c>const string</c> fields defined in the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type from which to retrieve constant string fields. Must inherit from <see cref="BaseAppearance"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A list of constant string values defined in the type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// Uses reflection to gather constants and caches them for future calls to improve performance.
+        /// </remarks>
+        internal static List<string> GetConstPaths<T>() where T : BaseAppearance
+        {
+            var type = typeof(T);
+            if (_constCache.TryGetValue(type, out var cached))
+                return cached;
+
+            var consts = new List<string>();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            foreach (var field in fields)
+            {
+                if (field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(string))
+                    consts.Add((string)field.GetRawConstantValue());
+            }
+
+            _constCache[type] = consts;
+            return consts;
+        }
+    }
+}

--- a/S1API/Entities/Appearances/Base/BaseBodyAppearance.cs
+++ b/S1API/Entities/Appearances/Base/BaseBodyAppearance.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace S1API.Entities.Appearances.Base
+{
+    /// <summary>
+    /// The base body appearance class
+    /// </summary>
+    /// <remarks>This is used to track the properties within the AvatarSettings</remarks>
+    public class BaseBodyAppearance
+    {
+        private static readonly Dictionary<Type, List<string>> _constCache = new Dictionary<Type, List<string>>();
+
+        /// <summary>
+        /// Retrieves and caches all public <c>const string</c> fields defined in the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type from which to retrieve constant string fields. Must inherit from <see cref="BaseBodyAppearance"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A list of constant string values defined in the type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// Uses reflection to gather constants and caches them for future calls to improve performance.
+        /// </remarks>
+        internal static List<string> GetConstPaths<T>() where T : BaseBodyAppearance
+        {
+            var type = typeof(T);
+            if (_constCache.TryGetValue(type, out var cached))
+                return cached;
+
+            var consts = new List<string>();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            foreach (var field in fields)
+            {
+                if (field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(string))
+                    consts.Add((string)field.GetRawConstantValue());
+            }
+
+            _constCache[type] = consts;
+            return consts;
+        }
+    }
+}

--- a/S1API/Entities/Appearances/Base/BaseFaceAppearance.cs
+++ b/S1API/Entities/Appearances/Base/BaseFaceAppearance.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace S1API.Entities.Appearances.Base
+{
+    /// <summary>
+    /// The base face appearance class
+    /// </summary>
+    /// <remarks>This is used to track the properties within the AvatarSettings</remarks>
+    public class BaseFaceAppearance
+    {
+        private static readonly Dictionary<Type, List<string>> _constCache = new Dictionary<Type, List<string>>();
+
+        /// <summary>
+        /// Retrieves and caches all public <c>const string</c> fields defined in the specified type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type from which to retrieve constant string fields. Must inherit from <see cref="BaseFaceAppearance"/>.
+        /// </typeparam>
+        /// <returns>
+        /// A list of constant string values defined in the type <typeparamref name="T"/>.
+        /// </returns>
+        /// <remarks>
+        /// Uses reflection to gather constants and caches them for future calls to improve performance.
+        /// </remarks>
+        internal static List<string> GetConstPaths<T>() where T : BaseFaceAppearance
+        {
+            var type = typeof(T);
+            if (_constCache.TryGetValue(type, out var cached))
+                return cached;
+
+            var consts = new List<string>();
+            var fields = type.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy);
+            foreach (var field in fields)
+            {
+                if (field is { IsLiteral: true, IsInitOnly: false } && field.FieldType == typeof(string))
+                    consts.Add((string)field.GetRawConstantValue());
+            }
+
+            _constCache[type] = consts;
+            return consts;
+        }
+    }
+}

--- a/S1API/Entities/Appearances/BodyLayerFields/Pants.cs
+++ b/S1API/Entities/Appearances/BodyLayerFields/Pants.cs
@@ -1,0 +1,16 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.BodyLayerFields
+{
+    /// <summary>
+    /// The Bottom index in AvatarSettings
+    /// </summary>
+    public class Pants : BaseBodyAppearance
+    {
+        public const string CargoPants = "Avatar/Layers/Bottom/CargoPants";
+        public const string FemaleUnderwear = "Avatar/Layers/Bottom/FemaleUnderwear";
+        public const string Jeans = "Avatar/Layers/Bottom/Jeans";
+        public const string Jorts = "Avatar/Layers/Bottom/Jorts";
+        public const string MaleUnderwear = "Avatar/Layers/Bottom/MaleUnderwear";
+    }
+}

--- a/S1API/Entities/Appearances/BodyLayerFields/Shirt.cs
+++ b/S1API/Entities/Appearances/BodyLayerFields/Shirt.cs
@@ -1,0 +1,24 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.BodyLayerFields
+{
+    /// <summary>
+    /// The Top index in AvatarSettings
+    /// </summary>
+    public class Shirts : BaseBodyAppearance
+    {
+        public const string Buttonup = "Avatar/Layers/Top/Buttonup";
+        public const string ChestHair = "Avatar/Layers/Top/ChestHair1";
+        public const string FastFoodTShirt = "Avatar/Layers/Top/FastFood T-Shirt";
+        public const string FlannelButtonUp = "Avatar/Layers/Top/FlannelButtonUp";
+        public const string GasStationTShirt = "Avatar/Layers/Top/GasStation T-Shirt";
+        public const string HazmatSuit = "Avatar/Layers/Top/HazmatSuit";
+        public const string Nipples = "Avatar/Layers/Top/Nipples";
+        public const string Overalls = "Avatar/Layers/Top/Overalls";
+        public const string RolledButtonUp = "Avatar/Layers/Top/RolledButtonUp";
+        public const string TShirt = "Avatar/Layers/Top/T-Shirt";
+        public const string TuckedTShirt = "Avatar/Layers/Top/Tucked T-Shirt";
+        public const string UpperBodyTattoos = "Avatar/Layers/Top/UpperBodyTattoos";
+        public const string VNeck = "Avatar/Layers/Top/V-Neck";
+    }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyeBallTint.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyeBallTint.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The EyeBallTint field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a Color type</remarks>
+    public class EyeBallTint : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyeLidRestingStateLeft.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyeLidRestingStateLeft.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The LeftEyeRestingState field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a (float, float) type</remarks>
+    public class EyeLidRestingStateLeft : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyeLidRestingStateRight.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyeLidRestingStateRight.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The RightEyeRestingState field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a (float, float) type</remarks>
+    public class EyeLidRestingStateRight : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyebrowRestingAngle.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyebrowRestingAngle.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The EyebrowRestingAngle field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class EyebrowRestingAngle : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyebrowRestingHeight.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyebrowRestingHeight.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The EyebrowRestingHeight field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class EyebrowRestingHeight : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyebrowScale.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyebrowScale.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The EyebrowScale field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class EyebrowScale : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/EyebrowThickness.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/EyebrowThickness.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The EyebrowThickness field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class EyebrowThickness : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/Gender.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/Gender.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The Gender field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class Gender : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/HairColor.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/HairColor.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The HairColor field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a Color type</remarks>
+    public class HairColor : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/HairStyle.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/HairStyle.cs
@@ -1,0 +1,37 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The HairPath field in AvatarSettings
+    /// </summary>
+    /// <remarks>
+    /// This contains all available hairstyles.
+    /// <br />
+    /// Is a string type.
+    /// </remarks>
+    public class HairStyle : BaseAppearance
+    {
+        public const string Afro = "Avatar/Hair/afro/Afro";
+        public const string Balding = "Avatar/Hair/balding/Balding";
+        public const string BowlCut = "Avatar/Hair/bowlcut/BowlCut";
+        public const string Bun = "Avatar/Hair/bun/Bun";
+        public const string BuzzCut = "Avatar/Hair/buzzcut/BuzzCut";
+        public const string DoubleTopKnot = "Avatar/Hair/doubletopknot/DoubleTopKnot";
+        public const string Franklin = "Avatar/Hair/franklin/Franklin";
+        public const string FringePonyTail = "Avatar/Hair/fringeponytail/FringePonyTail";
+        public const string HighBun = "Avatar/Hair/highbun/HighBun";
+        public const string Jesus = "Avatar/Hair/jesus/Jesus";
+        public const string LongCurly = "Avatar/Hair/longcurly/LongCurly";
+        public const string LowBun = "Avatar/Hair/lowbun/LowBun";
+        public const string MessyBob = "Avatar/Hair/messybob/MessyBob";
+        public const string MidFringe = "Avatar/Hair/midfringe/MidFringe";
+        public const string Mohawk = "Avatar/Hair/mohawk/Mohawk";
+        public const string Monk = "Avatar/Hair/monk/Monk";
+        public const string Peaked = "Avatar/Hair/peaked/Peaked";
+        public const string Receding = "Avatar/Hair/receding/Receding";
+        public const string ShoulderLength = "Avatar/Hair/shoulderlength/ShoulderLength";
+        public const string SidePartBob = "Avatar/Hair/sidepartbob/SidePartBob";
+        public const string Spiky = "Avatar/Hair/spiky/Spiky";
+    }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/Height.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/Height.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The Height field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class Height : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/PupilDilation.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/PupilDilation.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The PupilDilation field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class PupilDilation : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/SkinColor.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/SkinColor.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The SkinColor field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a Color type</remarks>
+    public class SkinColor : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/CustomizationFields/Weight.cs
+++ b/S1API/Entities/Appearances/CustomizationFields/Weight.cs
@@ -1,0 +1,10 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.CustomizationFields
+{
+    /// <summary>
+    /// The Weight field in AvatarSettings
+    /// </summary>
+    /// <remarks>Is a float type</remarks>
+    public class Weight : BaseAppearance { }
+}

--- a/S1API/Entities/Appearances/FaceLayerFields/Eyes.cs
+++ b/S1API/Entities/Appearances/FaceLayerFields/Eyes.cs
@@ -1,0 +1,15 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.FaceLayerFields
+{
+    /// <summary>
+    /// The EyeShadow index in AvatarSettings
+    /// </summary>
+    public class Eyes : BaseFaceAppearance
+    {
+        public const string EyeShadow = "Avatar/Layers/Face/EyeShadow";
+        public const string Freckles = "Avatar/Layers/Face/Freckles";
+        public const string OldPersonWrinkles = "Avatar/Layers/Face/OldPersonWrinkles";
+        public const string TiredEyes = "Avatar/Layers/Face/TiredEyes";
+    }
+}

--- a/S1API/Entities/Appearances/FaceLayerFields/Face.cs
+++ b/S1API/Entities/Appearances/FaceLayerFields/Face.cs
@@ -1,0 +1,23 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.FaceLayerFields
+{
+    /// <summary>
+    /// The Face index in FaceLayerSettings
+    /// </summary>
+    public class Face : BaseFaceAppearance
+    {
+        public const string Agape = "Avatar/Layers/Face/Face_Agape";
+        public const string Agited = "Avatar/Layers/Face/Face_Agited";
+        public const string FrownPout = "Avatar/Layers/Face/Face_FrownPout";
+        public const string Neutral = "Avatar/Layers/Face/Face_Neutral";
+        public const string NeutralPout = "Avatar/Layers/Face/Face_NeutralPout";
+        public const string OpenMouthSmile = "Avatar/Layers/Face/Face_OpenMouthSmile";
+        public const string Scared = "Avatar/Layers/Face/Face_Scared";
+        public const string SlightFrown = "Avatar/Layers/Face/Face_SlightFrown";
+        public const string SlightSmile = "Avatar/Layers/Face/Face_SlightSmile";
+        public const string Smile = "Avatar/Layers/Face/Face_Smile";
+        public const string SmugPout = "Avatar/Layers/Face/Face_SmugPout";
+        public const string Surprised = "Avatar/Layers/Face/Face_Surprised";
+    }
+}

--- a/S1API/Entities/Appearances/FaceLayerFields/FacialHair.cs
+++ b/S1API/Entities/Appearances/FaceLayerFields/FacialHair.cs
@@ -1,0 +1,14 @@
+﻿using S1API.Entities.Appearances.Base;
+
+namespace S1API.Entities.Appearances.FaceLayerFields
+{
+    /// <summary>
+    /// The FacialHair index in FaceLayerSettings
+    /// </summary>
+    public class FacialHair : BaseFaceAppearance
+    {
+        public const string Goatee = "Avatar/Layers/Face/FacialHair_Goatee";
+        public const string Stubble = "Avatar/Layers/Face/FacialHair_Stubble";
+        public const string Swirl = "Avatar/Layers/Face/FacialHair_Swirl";
+    }
+}

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -161,7 +161,6 @@ namespace S1API.Entities
             });
             S1NPC.awareness.VisionCone = visionCone;
 
-
             // Suspicious ? icon in world space
             S1NPC.awareness.VisionCone.QuestionMarkPopup = gameObject.AddComponent<S1WorkspacePopup.WorldspacePopup>();
 
@@ -182,10 +181,11 @@ namespace S1API.Entities
             // Pickpocket behaviour
             inventory.PickpocketIntObj = gameObject.AddComponent<S1Interaction.InteractableObject>();
 
-            // Defaulting to the local player for Avatar TODO: Change
-            S1NPC.Avatar = S1AvatarFramework.MugshotGenerator.Instance.MugshotRig;
+            // Set the appearance for the NPC
+            Appearance = new NPCAppearance(this);
 
             // Enable our custom gameObjects so they can initialize
+            gameObject.name = S1NPC.fullName;
             gameObject.SetActive(true);
 
             All.Add(this);
@@ -197,6 +197,14 @@ namespace S1API.Entities
         /// </summary>
         /// <param name="response">The response that was loaded.</param>
         protected virtual void OnResponseLoaded(Response response) { }
+
+        /// <summary>
+        /// Override OnCreated to create the Mugshot for the NPC
+        /// </summary>
+        protected override void OnCreated()
+        {
+            Appearance.GenerateMugshot();
+        }
 
         #endregion
 
@@ -529,6 +537,11 @@ namespace S1API.Entities
             add => EventHelper.AddListener(value, S1NPC.Inventory.onContentsChanged);
             remove => EventHelper.RemoveListener(value, S1NPC.Inventory.onContentsChanged);
         }
+
+        /// <summary>
+        /// The current <see cref="NPCAppearance"/> instance.
+        /// </summary>
+        public NPCAppearance Appearance { get; private set; }
 
         /// <summary>
         /// Sends a text message from this NPC to the players.

--- a/S1API/Entities/NPC.cs
+++ b/S1API/Entities/NPC.cs
@@ -185,7 +185,7 @@ namespace S1API.Entities
             Appearance = new NPCAppearance(this);
 
             // Enable our custom gameObjects so they can initialize
-            gameObject.name = S1NPC.fullName;
+            gameObject.name = S1NPC.FirstName ?? "UnknownNPC";
             gameObject.SetActive(true);
 
             All.Add(this);

--- a/S1API/Entities/NPCAppearance.cs
+++ b/S1API/Entities/NPCAppearance.cs
@@ -1,0 +1,433 @@
+﻿#if (IL2CPPMELON)
+using S1AvatarFramework = Il2CppScheduleOne.AvatarFramework;
+#elif (MONOMELON || MONOBEPINEX || IL2CPPBEPINEX)
+using S1AvatarFramework = ScheduleOne.AvatarFramework;
+#endif
+
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+using S1API.Entities.Appearances.AccessoryFields;
+using S1API.Entities.Appearances.Base;
+using S1API.Entities.Appearances.BodyLayerFields;
+using S1API.Entities.Appearances.CustomizationFields;
+using S1API.Entities.Appearances.FaceLayerFields;
+using S1API.Internal.Utils;
+using S1API.Logging;
+
+namespace S1API.Entities
+{
+    /// <summary>
+    ///
+    /// </summary>
+    public class NPCAppearance
+    {
+        private static readonly Log _logger = new Log("NPCAppearance");
+
+        #region Internal Members
+
+        /// <summary>
+        /// INTERNAL: Reference to the NPC on API side
+        /// </summary>
+        internal readonly NPC NPC;
+
+        /// <summary>
+        /// INTERNAL: Constructor used for assigning the NPC instance.
+        /// </summary>
+        /// <param name="npc"></param>
+        internal NPCAppearance(NPC npc)
+        {
+            NPC = npc;
+
+            // Defaulting to the local player for Avatar
+            NPC.S1NPC.Avatar = S1AvatarFramework.MugshotGenerator.Instance.MugshotRig;
+
+            // Create the new AvatarSettings by default
+            _customAvatarSettings = ScriptableObject.CreateInstance<S1AvatarFramework.AvatarSettings>();
+            ApplyDefaultSettings(_customAvatarSettings);
+
+            // Assign the appearance for already existing NPCs with existing AvatarSettings
+            S1AvatarFramework.AvatarSettings avatarSettings = Resources.Load<S1AvatarFramework.AvatarSettings>($"charactersettings/{NPC.S1NPC.FirstName}");
+            NPC.S1NPC.Avatar.LoadAvatarSettings(avatarSettings);
+        }
+
+        /// <summary>
+        /// Generate the Mugshot for the <see cref="NPC"/> instance
+        /// </summary>
+        internal void GenerateMugshot()
+        {
+            // Enable the MugshotRig GameObject, if we do not do this the Mugshots are blank.
+            S1AvatarFramework.MugshotGenerator.Instance.MugshotRig.transform.parent.gameObject.SetActive(true);
+
+            // Grab the right AvatarSettings instance to use
+            if (!NPC.S1NPC.Avatar.InitialAvatarSettings)
+                NPC.S1NPC.Avatar.LoadAvatarSettings(_customAvatarSettings);
+
+            // Generate the Mugshot for the NPC
+            NPC.S1NPC.Avatar.GetMugshot((Action<Texture2D>)(generatedMugshot =>
+            {
+                // Apply the generated Texture2D instance to the GPU
+                // Otherwise it'll be blank in Messages App (for example).
+                generatedMugshot.Apply();
+
+                // Create the sprite and assign it to the NPC Icon.
+                Sprite iconSprite = Sprite.Create(generatedMugshot, new Rect(0, 0, generatedMugshot.width, generatedMugshot.height), Vector2.zero);
+                NPC.Icon = iconSprite;
+            }));
+        }
+
+        #endregion
+
+        #region Public Members
+
+        /// <summary>
+        /// Sets an appearance field within <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <typeparam name="T">The appearance type</typeparam>
+        /// <param name="appearanceValue">The value to set</param>
+        public NPCAppearance Set<T>(object appearanceValue) where T : BaseAppearance
+        {
+            if (_setters.TryGetValue(typeof(T), out var setter))
+            {
+                try
+                {
+                    setter(this, appearanceValue);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"Failed to set {typeof(T).Name}: {ex.Message}");
+                }
+            }
+            else
+                _logger.Error($"No setter registered for appearance type {typeof(T).Name}");
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a Face Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="hexColor">The color in Hexadecimals</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithFaceLayer<T>(string path, uint hexColor) where T : BaseFaceAppearance =>
+            WithFaceLayer<T>(path, hexColor.ToColor());
+
+        /// <summary>
+        /// Adds a Face Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="color">The color instance</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithFaceLayer<T>(string path, Color color) where T : BaseFaceAppearance
+        {
+            if (_customAvatarSettings.FaceLayerSettings.Count > MaxFaceLayers)
+                return this;
+
+            _customAvatarSettings.FaceLayerSettings.Add(new S1AvatarFramework.AvatarSettings.LayerSetting
+            {
+                layerPath = path,
+                layerTint =  color
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a Body Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="hexColor">The color in Hexadecimals</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithBodyLayer<T>(string path, uint hexColor) where T : BaseBodyAppearance =>
+            WithBodyLayer<T>(path, hexColor.ToColor());
+
+        /// <summary>
+        /// Adds a Body Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="color">The color instance</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithBodyLayer<T>(string path, Color color) where T : BaseBodyAppearance
+        {
+            if (_customAvatarSettings.BodyLayerSettings.Count > MaxBodyLayers)
+                return this;
+
+            _customAvatarSettings.BodyLayerSettings.Add(new S1AvatarFramework.AvatarSettings.LayerSetting
+            {
+                layerPath = path,
+                layerTint =  color
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a Accessory Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="hexColor">The color in Hexadecimals</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithAccessoryLayer<T>(string path, uint hexColor) where T : BaseAccessoryAppearance =>
+            WithAccessoryLayer<T>(path, hexColor.ToColor());
+
+        /// <summary>
+        /// Adds a Accessory Layer within the <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <param name="path">The asset path</param>
+        /// <param name="color">The color instance</param>
+        /// <typeparam name="T"></typeparam>
+        public NPCAppearance WithAccessoryLayer<T>(string path, Color color) where T : BaseAccessoryAppearance
+        {
+            if (_customAvatarSettings.AccessorySettings.Count > MaxAccessoryLayers)
+                return this;
+
+            _customAvatarSettings.AccessorySettings.Add(new S1AvatarFramework.AvatarSettings.AccessorySetting
+            {
+                path = path,
+                color =  color
+            });
+
+            return this;
+        }
+
+        /// <summary>
+        /// Finalizes the appearance by generating the NPC's mugshot.
+        /// This can be called after setting all appearance attributes.
+        /// </summary>
+        /// <returns>The <see cref="NPCAppearance"/> instance with the generated mugshot.</returns>
+        public NPCAppearance Build()
+        {
+            GenerateMugshot();
+            return this;
+        }
+
+        /// <summary>
+        /// Generates a random appearance for the <see cref="NPC"/>
+        /// </summary>
+        public void GenerateRandomAppearance()
+        {
+            Color RandomColor() => new Color(UnityEngine.Random.value, UnityEngine.Random.value, UnityEngine.Random.value);
+            float RandomRange(float min, float max) => UnityEngine.Random.Range(min, max);
+            string RandomFromList(List<string> list) => list[UnityEngine.Random.Range(0, list.Count)];
+
+            #region Customization Fields
+
+            // Customization fields
+            Set<EyeBallTint>(RandomColor());
+            Set<EyebrowRestingAngle>(RandomRange(0f, 1f));
+            Set<EyebrowRestingHeight>(RandomRange(0f, 1f));
+            Set<EyebrowScale>(RandomRange(0f, 1f));
+            Set<EyebrowThickness>(RandomRange(0f, 1f));
+
+            float topLid = RandomRange(0f, 1f);
+            float bottomLid = RandomRange(0f, 1f);
+            Set<EyeLidRestingStateLeft>((topLid, bottomLid));
+            Set<EyeLidRestingStateRight>((topLid, bottomLid));
+
+            // Hair
+            var hairColor = RandomColor();
+            Set<HairColor>(hairColor);
+
+            var hairStyles = BaseAppearance.GetConstPaths<HairStyle>();
+            if (hairStyles.Count > 0)
+                Set<HairStyle>(RandomFromList(hairStyles));
+
+            Set<Gender>(RandomRange(0f, 1f));
+            Set<Height>(RandomRange(0.8f, 1.2f));
+            Set<PupilDilation>(RandomRange(0f, 1f));
+            Set<SkinColor>(RandomColor());
+            Set<Weight>(RandomRange(0f, 1f));
+
+            #endregion
+
+            #region Face Layers
+
+            var faceColor = RandomColor();
+
+            // Required: Eyes and Face
+            var eyes = BaseFaceAppearance.GetConstPaths<Eyes>();
+            if (eyes.Count > 0)
+                WithFaceLayer<Eyes>(RandomFromList(eyes), faceColor);
+
+            var faces = BaseFaceAppearance.GetConstPaths<Face>();
+            if (faces.Count > 0)
+                WithFaceLayer<Face>(RandomFromList(faces), faceColor);
+
+            // Optional: FacialHair (50% chance)
+            if (UnityEngine.Random.value < 0.5f)
+            {
+                var facialHair = BaseFaceAppearance.GetConstPaths<FacialHair>();
+                if (facialHair.Count > 0)
+                    WithFaceLayer<FacialHair>(RandomFromList(facialHair), hairColor);
+            }
+
+            #endregion
+
+            #region Body Layers
+
+            var bodyTypes = new (Type type, Action<string, Color> apply)[]
+            {
+                (typeof(Shirts), (path, color) => WithBodyLayer<Shirts>(path, color)),
+                (typeof(Pants), (path, color) => WithBodyLayer<Pants>(path, color))
+            };
+            foreach (var (type, apply) in bodyTypes.OrderBy(_ => Guid.NewGuid()).Take(UnityEngine.Random.Range(1, 3)))
+            {
+                MethodInfo method = AccessTools.Method(typeof(BaseBodyAppearance), "GetConstPaths").MakeGenericMethod(type);
+                List<string> paths = (List<string>)method.Invoke(null, null);
+                if (paths?.Count > 0)
+                    apply(RandomFromList(paths), RandomColor());
+            }
+
+            #endregion
+
+            #region Accessory Layers
+
+            var accessoryLayers = new (Type type, Action<string, Color> apply)[]
+            {
+                (typeof(Bottom), (path, color) => WithAccessoryLayer<Bottom>(path, color)),
+                (typeof(Chest), (path, color) => WithAccessoryLayer<Chest>(path, color)),
+                (typeof(Feet), (path, color) => WithAccessoryLayer<Feet>(path, color)),
+                (typeof(Hands), (path, color) => WithAccessoryLayer<Hands>(path, color)),
+                (typeof(Head), (path, color) => WithAccessoryLayer<Head>(path, color)),
+                (typeof(Neck), (path, color) => WithAccessoryLayer<Neck>(path, color)),
+                (typeof(Waist), (path, color) => WithAccessoryLayer<Waist>(path, color))
+            };
+            foreach (var (type, apply) in accessoryLayers.OrderBy(_ => Guid.NewGuid()).Take(UnityEngine.Random.Range(2, 6)))
+            {
+                MethodInfo method = AccessTools.Method(typeof(BaseAccessoryAppearance), "GetConstPaths").MakeGenericMethod(type);
+                List<string> paths = (List<string>)method.Invoke(null, null);
+                if (paths?.Count > 0)
+                    apply(RandomFromList(paths), RandomColor());
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region Private Members
+
+        /// <summary>
+        /// INTERNAL: Set's default values to <see cref="S1AvatarFramework.AvatarSettings"/>
+        /// </summary>
+        /// <remarks>This function is grabbed from the client code</remarks>
+        /// <param name="avatarSettings">The AvatarSettings to assign defaults to</param>
+        private static void ApplyDefaultSettings(S1AvatarFramework.AvatarSettings avatarSettings)
+        {
+            avatarSettings.SkinColor = new Color32(150, 120, 95, byte.MaxValue);
+            avatarSettings.Height = 0.98f;
+            avatarSettings.Gender = 0.0f;
+            avatarSettings.Weight = 0.4f;
+            avatarSettings.EyebrowScale = 1f;
+            avatarSettings.EyebrowThickness = 1f;
+            avatarSettings.EyebrowRestingHeight = 0.0f;
+            avatarSettings.EyebrowRestingAngle = 0.0f;
+            avatarSettings.LeftEyeLidColor = new Color32(150, 120, 95, byte.MaxValue);
+            avatarSettings.RightEyeLidColor = new Color32(150, 120, 95, byte.MaxValue);
+            avatarSettings.LeftEyeRestingState = new S1AvatarFramework.Eye.EyeLidConfiguration
+            {
+                bottomLidOpen = 0.5f,
+                topLidOpen = 0.5f
+            };
+            avatarSettings.RightEyeRestingState = new S1AvatarFramework.Eye.EyeLidConfiguration
+            {
+                bottomLidOpen = 0.5f,
+                topLidOpen = 0.5f
+            };
+            avatarSettings.EyeballMaterialIdentifier = "Default";
+            avatarSettings.EyeBallTint = Color.white;
+            avatarSettings.PupilDilation = 1f;
+            avatarSettings.HairPath = string.Empty;
+            avatarSettings.HairColor = Color.black;
+        }
+
+        /// <summary>
+        /// INTERNAL: The custom <see cref="S1AvatarFramework.AvatarSettings"/> instance used for modders
+        /// </summary>
+        private S1AvatarFramework.AvatarSettings _customAvatarSettings;
+
+        /// <summary>
+        /// INTERNAL: Setters for each individual property (blame IL2CPP)
+        /// </summary>
+        private static readonly Dictionary<Type, Action<NPCAppearance, object>> _setters = new Dictionary<Type, Action<NPCAppearance, object>>
+        {
+            [typeof(HairStyle)] = (self, value) => self._customAvatarSettings.HairPath = value as string ?? string.Empty,
+            [typeof(HairColor)] = (self, value) =>
+            {
+                self._customAvatarSettings.HairColor = value switch
+                {
+                    uint hex => hex.ToColor(),
+                    Color color => color,
+                    _ => self._customAvatarSettings.HairColor
+                };
+            },
+            [typeof(SkinColor)] = (self, value) =>
+            {
+                self._customAvatarSettings.SkinColor = value switch
+                {
+                    uint hex => hex.ToColor(),
+                    Color color => color,
+                    _ => self._customAvatarSettings.SkinColor
+                };
+            },
+            [typeof(EyeBallTint)] = (self, value) =>
+            {
+                self._customAvatarSettings.EyeBallTint = value switch
+                {
+                    uint hex => hex.ToColor(),
+                    Color color => color,
+                    _ => self._customAvatarSettings.EyeBallTint
+                };
+            },
+            [typeof(Gender)] = (self, value) => self._customAvatarSettings.Gender = Convert.ToSingle(value),
+            [typeof(Height)] = (self, value) => self._customAvatarSettings.Height = Convert.ToSingle(value),
+            [typeof(Weight)] = (self, value) => self._customAvatarSettings.Weight = Convert.ToSingle(value),
+            [typeof(PupilDilation)] = (self, value) => self._customAvatarSettings.PupilDilation = Convert.ToSingle(value),
+            [typeof(EyebrowRestingAngle)] = (self, value) => self._customAvatarSettings.EyebrowRestingAngle = Convert.ToSingle(value),
+            [typeof(EyebrowRestingHeight)] = (self, value) => self._customAvatarSettings.EyebrowRestingHeight = Convert.ToSingle(value),
+            [typeof(EyebrowScale)] = (self, value) => self._customAvatarSettings.EyebrowScale = Convert.ToSingle(value),
+            [typeof(EyebrowThickness)] = (self, value) => self._customAvatarSettings.EyebrowThickness = Convert.ToSingle(value),
+            [typeof(EyeLidRestingStateLeft)] = (self, value) =>
+            {
+                var items = value.GetValueTupleItems();
+                self._customAvatarSettings.LeftEyeRestingState = new S1AvatarFramework.Eye.EyeLidConfiguration
+                {
+                    topLidOpen = Convert.ToSingle(items![0]),
+                    bottomLidOpen = Convert.ToSingle(items![1])
+                };
+            },
+            [typeof(EyeLidRestingStateRight)] = (self, value) =>
+            {
+                var items = value.GetValueTupleItems();
+                self._customAvatarSettings.RightEyeRestingState = new S1AvatarFramework.Eye.EyeLidConfiguration
+                {
+                    topLidOpen = Convert.ToSingle(items![0]),
+                    bottomLidOpen = Convert.ToSingle(items![1])
+                };
+            }
+        };
+
+        /// <summary>
+        /// INTERNAL: The max amount of layers for the Face
+        /// </summary>
+        private const int MaxFaceLayers = 6;
+
+        /// <summary>
+        /// INTERNAL: The max amount of layers for the Body
+        /// </summary>
+        private const int MaxBodyLayers = 6;
+
+        /// <summary>
+        /// INTERNAL: The max amount of layers for Accessories
+        /// </summary>
+        private const int MaxAccessoryLayers = 9;
+
+        #endregion
+
+    }
+}

--- a/S1API/Internal/Utils/ColorUtils.cs
+++ b/S1API/Internal/Utils/ColorUtils.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+
+namespace S1API.Internal.Utils
+{
+    /// <summary>
+    /// Utilities for the <see cref="Color"/> class
+    /// </summary>
+    public static class ColorUtils
+    {
+        /// <summary>
+        /// Convert's a <see cref="int"/> value to <see cref="Color"/>
+        /// </summary>
+        /// <param name="hexColor"></param>
+        /// <returns></returns>
+        public static Color ToColor(this uint hexColor)
+            => ToColorInternal(hexColor);
+
+        private static Color ToColorInternal(uint hexColor)
+        {
+            float a = (hexColor >> 24 & 0xFF) / 255f;
+            float r = (hexColor >> 16 & 0xFF) / 255f;
+            float g = (hexColor >> 8 & 0xFF) / 255f;
+            float b = (hexColor & 0xFF) / 255f;
+            return new Color(r, g, b, a);
+        }
+    }
+}

--- a/S1API/Internal/Utils/ReflectionUtils.cs
+++ b/S1API/Internal/Utils/ReflectionUtils.cs
@@ -96,5 +96,56 @@ namespace S1API.Internal.Utils
 
             return null;
         }
+
+        /// <summary>
+        /// INTERNAL: The different ValueTuple types.
+        /// </summary>
+        private static readonly HashSet<Type> _valueTupleTypes = new HashSet<Type>()
+        {
+            typeof(ValueTuple<>),
+            typeof(ValueTuple<,>),
+            typeof(ValueTuple<,,>),
+            typeof(ValueTuple<,,,>),
+            typeof(ValueTuple<,,,,>),
+            typeof(ValueTuple<,,,,,>),
+            typeof(ValueTuple<,,,,,,>),
+            typeof(ValueTuple<,,,,,,,>)
+        };
+
+        /// <summary>
+        /// INTERNAL: Checks whether the object is a ValueTuple
+        /// </summary>
+        /// <param name="obj">The object type to check</param>
+        /// <returns>Whether the type is a ValueTuple or not</returns>
+        public static bool IsValueTuple(this object obj)
+        {
+            if (obj == null)
+                return false;
+
+            var type = obj.GetType();
+            if (!type.IsValueType || !type.IsGenericType)
+                return false;
+
+            var genericType = type.GetGenericTypeDefinition();
+            return _valueTupleTypes.Contains(genericType);
+        }
+
+        /// <summary>
+        /// INTERNAL: Retrieves the Items from the ValueTuple instance.
+        /// </summary>
+        /// <param name="obj">The ValueTuple instance</param>
+        /// <returns>The items in the ValueTuple instance.</returns>
+        public static object[]? GetValueTupleItems(this object obj)
+        {
+            if (!obj.IsValueTuple())
+                return null;
+
+            var fields = GetAllFields(obj.GetType(), BindingFlags.Instance | BindingFlags.Public);
+            if (fields == null || fields.Length == 0)
+                return null;
+
+            return fields.Select(f => f.GetValue(obj))
+                .ToArray();
+        }
     }
 }

--- a/S1API/S1API.csproj
+++ b/S1API/S1API.csproj
@@ -63,6 +63,7 @@
 
     <!-- Mono Specific Deps -->
     <ItemGroup Condition="'$(Configuration)' == 'MonoMelon' or '$(Configuration)' == 'MonoBepInEx'">
+<!--        <Reference Include="$(MonoAssembliesPath)\Assembly-CSharp.dll" Publicize="true" />-->
         <Reference Include="$(MonoAssembliesPath)\Assembly-CSharp.dll" />
         <Reference Include="$(MonoAssembliesPath)\UnityEngine.dll" />
         <Reference Include="$(MonoAssembliesPath)\UnityEngine.CoreModule.dll" />
@@ -89,10 +90,11 @@
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.32" IncludeAssets="compile" Condition="'$(Configuration)' == 'MonoBepInEx'" />
     </ItemGroup>
-
+    
     <!-- Shared Deps -->
     <ItemGroup>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+<!--        <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.5.0-beta.1" PrivateAssets="all" Condition="'$(Configuration)' == 'MonoBepInEx' or '$(Configuration)' == 'MonoMelon'"/>-->
     </ItemGroup>
 
     <!-- Automated local deployment -->


### PR DESCRIPTION
Implement custom NPC appearance system, also assign existing appearances to already existing NPCs.

## Example Usage

Setting pre-defined customizations
```cs
public class TestNpc : NPC
{
    public TestNpc() : base("test_npc", "Test", "Npc")
    {
        Appearance.Set<HairStyle>(HairStyle.Afro)
            .Set<HairColor>(0xFF00315C)
            .WithFaceLayer<FacialHair>(FacialHair.Goatee, 0xFF000000)
            .WithFaceLayer<Eyes>(Eyes.EyeShadow, 0xC8000000)
            .WithAccessoryLayer<Head>(Head.BucketHat, 0xFF32C02C);

    }
}
```
> NOTE: `Color` fields are either Hexadecimal codes (`0xAARRGGBB`) or `Color` type from `UnityEngine`

Random customization:
```cs
public class TestNpc : NPC
{
    public TestNpc() : base("test_npc", "Test", "Npc")
    {
        Appearance.GenerateRandomAppearance();
    }
}
```

## Customization Fields (`Set<T>`)
- EyeballTint (color field)
- EyebrowRestingAngle (float field 0 - 1)
- EyebrowRestingHeight (float field 0 - 1)
- EyebrowScale (float field 0 - 1)
- EyebrowThickness (float field 0 - 1)
- EyeLidRestingStateLeft (float field 0 - 1)
- EyeLidRestingStateRight (float field 0 - 1)
- Gender (float field 0 - 1)
- HairColor (color field)
- HairStyle
- Height (float field 0.8 - 1.2)
- PupilDilation (float field 0 - 1)
- SkinColor (color field)
- Weight (float field 0 - 1)

## Body Layer Fields (`WithBodyLayer<T>`)
- Pants
- Shirt

## Face Layer Fields (`WithFaceLayer<T>`)
- Eyes
- Face
- FacialHair

## Accessory Fields (`WithAccessoryLayer<T>`)
- Bottom
- Chest
- Feet
- Hands
- Head
- Neck
- Waist
